### PR TITLE
Feat/25 email list

### DIFF
--- a/src/main/java/com/example/rework/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/rework/config/security/SecurityConfig.java
@@ -63,10 +63,10 @@ public class SecurityConfig {
                 .addFilterBefore(new JwtAuthorizationFilter(authenticationManager(), memberService, jwtProvider), UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests((authorizeRequests) ->
                         authorizeRequests
-                                .requestMatchers("/api/v1/members/signup", "/api/v1/members/login/**","/api/v1/members/renew-access-token","/api/v1/members/logout").permitAll()
+                                .requestMatchers("/api/v1/members/signup", "/api/v1/members/login/**","/api/v1/members/renew-access-token","/api/v1/members/logout","/api/v1/members/register-email").permitAll()
                                 .requestMatchers("/api/v1/dailyAgenda/**").hasAnyAuthority("ADMIN", "MEMBER")
                                 .requestMatchers("/api/v1/monthlyAgenda/**").hasAnyAuthority("ADMIN", "MEMBER")
-                                .requestMatchers("/api/v1/mails/send/**").hasAuthority("ADMIN")
+                                .requestMatchers("/api/v1/members/admin/**").hasAnyAuthority("ADMIN")
                                 .requestMatchers("/swagger-ui/**").permitAll()
                                 .requestMatchers("/v3/api-docs/**").permitAll()
                                 .anyRequest().authenticated()
@@ -112,7 +112,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowCredentials(true);
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173"));
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173","https://rework-eight.vercel.app"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST","PUT","DELETE","PATCH"));
         configuration.addAllowedHeader("*");
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/example/rework/discord/WebhookService.java
+++ b/src/main/java/com/example/rework/discord/WebhookService.java
@@ -21,12 +21,14 @@ public class WebhookService {
     // 디스코드 웹훅 URL 주입
     @Value("${discord.webhook.url}")
     private String discordWebhookUrl;
+    @Value("${discord.webhook.wating-approve}")
+    private String discordWebhookUrl2;
+
     private final MemberRepository memberRepository;
 
     // 알림을 보내는 메서드
     @Transactional
-    public boolean sendDiscordNotification(String email) {
-
+    public boolean sendDiscordNotificationForRegister(String email) {
         try {
             // REST 요청을 처리하기 위한 RestTemplate 객체 생성
             RestTemplate restTemplate = new RestTemplate();
@@ -35,25 +37,58 @@ public class WebhookService {
             Long totalMembers = memberRepository.count();
 
             // 알림 메시지 생성
-            String message = " 🎉 Rework 서비스에 "+email+"님이 "+totalMembers+"번째로 회원가입 했습니다! 🎉";
+            String message = " 🎉 Rework 서비스에 " + email + "님이 " + totalMembers + "번째로 회원가입 했습니다! 🎉";
 
             // HTTP 요청을 위한 헤더 설정
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);
 
-            // HTTP 요청 바디에 전송할 메시지 설정
-            Map<String, String> body = new HashMap<>();
-            body.put("content", message);
+            // HTTP 요청 바디에 전송할 메시지 설정 (Embed 구조)
+            Map<String, Object> embed = new HashMap<>();
+            embed.put("title", "New Member Signup");
+            embed.put("description", message);
+            embed.put("color", 65280); // Green color in decimal
+            embed.put("footer", Map.of("text", "Rework Service Notification"));
+
+            Map<String, Object> body = new HashMap<>();
+            body.put("embeds", new Map[]{embed});
 
             // HTTP 요청 엔터티 생성
-            HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(body, headers);
+            HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(body, headers);
 
             // 디스코드 웹훅 URL로 POST 요청을 보내어 알림을 전송
             restTemplate.postForEntity(discordWebhookUrl, requestEntity, String.class);
 
             return true;
-        }catch (Exception e) {
-            throw new InvalidDiscordMessage("디스코드 메시지 전송에 실패했습니다."+e.getMessage());
+        } catch (Exception e) {
+            throw new InvalidDiscordMessage("디스코드 메시지 전송에 실패했습니다. " + e.getMessage());
+        }
+    }
+
+
+    public boolean sendDiscordNotificationForNonMemberRegister(String email) {
+        try {
+            RestTemplate restTemplate = new RestTemplate();
+            String message = "🎉 A new member signup request from " + email + "!";
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            Map<String, Object> embed = new HashMap<>();
+            embed.put("title", "New Signup Request");
+            embed.put("description", message);
+            embed.put("color", 16776960); // Yellow color in decimal
+            embed.put("footer", Map.of("text", "Rework Service Notification"));
+
+            Map<String, Object> body = new HashMap<>();
+            body.put("embeds", new Map[]{embed});
+
+            HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+            restTemplate.postForEntity(discordWebhookUrl2, requestEntity, String.class);
+
+            return true;
+        } catch (Exception e) {
+            throw new InvalidDiscordMessage("Failed to send Discord message: " + e.getMessage());
         }
     }
 }

--- a/src/main/java/com/example/rework/mail/application/impl/MailSenderServiceImpl.java
+++ b/src/main/java/com/example/rework/mail/application/impl/MailSenderServiceImpl.java
@@ -49,7 +49,7 @@ public class MailSenderServiceImpl implements MailSenderService {
         MemberCreateResponseDto member = memberService.createMember(signUpRequestDto);
         //회원가입 한 이메일로 랜덤 비밀번호 전송
         if(mailSenderApi.sendRandomPasswordMail(sendMailDto,randomPassword)){
-            webhookService.sendDiscordNotification(email);
+            webhookService.sendDiscordNotificationForRegister(email);
             return true;
         }
         return false;

--- a/src/main/java/com/example/rework/mail/infra/MailSenderApi.java
+++ b/src/main/java/com/example/rework/mail/infra/MailSenderApi.java
@@ -30,7 +30,8 @@ public class MailSenderApi {
 
         //템플릿에 전달할 데이터 설정
         Context context = new Context();
-        context.setVariable("randomNumber", randomPassword);
+        context.setVariable("randompassword", randomPassword);
+        context.setVariable("email", sendMailDto.getEmail());
 
         //메일 내용 설정 : 템플릿 프로세스
         String html = templateEngine.process("acceptEmail.html",context);

--- a/src/main/java/com/example/rework/mail/presentation/MailSenderController.java
+++ b/src/main/java/com/example/rework/mail/presentation/MailSenderController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Slf4j
-@RequestMapping("/api/v1/mails")
+@RequestMapping("/api/v1/admin/mails")
 @RequiredArgsConstructor
 public class MailSenderController implements EmailApi {
 

--- a/src/main/java/com/example/rework/member/application/MemberService.java
+++ b/src/main/java/com/example/rework/member/application/MemberService.java
@@ -6,6 +6,8 @@ import com.example.rework.member.application.dto.MemeberRequestDto;
 import com.example.rework.member.domain.Member;
 import org.springframework.security.core.Authentication;
 
+import java.util.List;
+
 public interface MemberService {
     MemberResponseDto.MemberCreateResponseDto createMember(MemeberRequestDto.SignUpRequestDto signUpRequestDto);
     Member findMemberByUserId(String username);
@@ -13,4 +15,9 @@ public interface MemberService {
     void memberLogout(String username);
 
     boolean updatePassword(MemeberRequestDto.MemberUpdatePasswordRequestDto updatePasswordRequestDto, SecurityUtils securityUtils);
+
+    boolean registerEmail(MemeberRequestDto.RegisterEmailRequestDto registerEmailRequestDto);
+
+    List<MemberResponseDto.NonMemberEmailListResponseDto> adminNonMemberEamilList(SecurityUtils securityUtils);
+
 }

--- a/src/main/java/com/example/rework/member/application/dto/MemberResponseDto.java
+++ b/src/main/java/com/example/rework/member/application/dto/MemberResponseDto.java
@@ -3,10 +3,12 @@ package com.example.rework.member.application.dto;
 
 
 import com.example.rework.member.domain.Member;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.example.rework.member.domain.NonMemberEmail;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.time.LocalDateTime;
 
 public class MemberResponseDto {
 	@Getter
@@ -35,5 +37,27 @@ public class MemberResponseDto {
 		}
 
 	}
+
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	@Getter
+	@Builder
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class NonMemberEmailListResponseDto {
+
+		@NotEmpty(message = "아이디 설정은 필수입니다.")
+		@Size(min = 4, max = 32, message = "아이디를 4~32글자로 설정해주세요.")
+		private String email;
+
+		private Long NonMemberEmailId;
+
+		private LocalDateTime createdAt;
+
+		public NonMemberEmailListResponseDto(NonMemberEmail nonMemberEmail) {
+			this.email = nonMemberEmail.getEmail();
+			this.NonMemberEmailId = nonMemberEmail.getId();
+			this.createdAt = nonMemberEmail.getCreatedAt();
+		}
+	}
+
 
 }

--- a/src/main/java/com/example/rework/member/application/dto/MemeberRequestDto.java
+++ b/src/main/java/com/example/rework/member/application/dto/MemeberRequestDto.java
@@ -2,10 +2,13 @@ package com.example.rework.member.application.dto;
 
 import com.example.rework.auth.MemberRole;
 import com.example.rework.member.domain.Member;
+import com.example.rework.member.domain.NonMemberEmail;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+
+import java.time.LocalDateTime;
 
 public class MemeberRequestDto {
 
@@ -86,6 +89,17 @@ public class MemeberRequestDto {
         @Size(min = 8, max = 64, message = "비밀번호를 8~64글자의 영문+숫자 조합으로 설정해주세요.")
         @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)[a-zA-Z\\d]+$", message = "비밀번호는 영문과 숫자의 조합이어야 합니다.")
         private String newPassword;
+    }
+
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class RegisterEmailRequestDto {
+
+        @NotEmpty(message = "아이디 설정은 필수입니다.")
+        @Size(min = 4, max = 32, message = "아이디를 4~32글자로 설정해주세요.")
+        private String email;
     }
 
 }

--- a/src/main/java/com/example/rework/member/application/impl/MemberServiceImpl.java
+++ b/src/main/java/com/example/rework/member/application/impl/MemberServiceImpl.java
@@ -52,6 +52,8 @@ public class MemberServiceImpl implements MemberService {
         SignUpRequestDto encodingDto = encodingPassword(signUpRequestDto);
         //회원 저장
         Member member = memberRepository.save(encodingDto.toEntity());
+        NonMemberEmail nonMemberEmail = nonMemberRepository.findByEmail(member.getUserId());
+        nonMemberEmail.updateIsAccepted(true);
         return MemberResponseDto.MemberCreateResponseDto.builder()
                 .memberRole(String.valueOf(member.getRole()))
                 .userId(member.getUserId())

--- a/src/main/java/com/example/rework/member/domain/NonMemberEmail.java
+++ b/src/main/java/com/example/rework/member/domain/NonMemberEmail.java
@@ -20,4 +20,8 @@ public class NonMemberEmail extends BaseTimeEntity {
     // 회원가입 승인 여부
     @Column(name = "IS_ACCEPTED", nullable = false)
     private boolean isAccepted;
+
+    public void updateIsAccepted(boolean state) {
+        this.isAccepted = state;
+    }
 }

--- a/src/main/java/com/example/rework/member/domain/NonMemberEmail.java
+++ b/src/main/java/com/example/rework/member/domain/NonMemberEmail.java
@@ -1,0 +1,23 @@
+package com.example.rework.member.domain;
+
+import com.example.rework.auth.MemberRole;
+import com.example.rework.global.base.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity(name = "NON_MEMBER")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class NonMemberEmail extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "NON_MEMBER_ID")
+    private Long id;
+    @Column(length = 100, nullable = false, unique = true)
+    private String email;
+    // 회원가입 승인 여부
+    @Column(name = "IS_ACCEPTED", nullable = false)
+    private boolean isAccepted;
+}

--- a/src/main/java/com/example/rework/member/domain/repository/NonMemberRepository.java
+++ b/src/main/java/com/example/rework/member/domain/repository/NonMemberRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 
 public interface NonMemberRepository extends JpaRepository<NonMemberEmail,Long> {
      List<NonMemberEmail> findAllByIsAccepted(boolean isAccepted);
+
+    NonMemberEmail findByEmail(String Email);
 }

--- a/src/main/java/com/example/rework/member/domain/repository/NonMemberRepository.java
+++ b/src/main/java/com/example/rework/member/domain/repository/NonMemberRepository.java
@@ -1,0 +1,11 @@
+package com.example.rework.member.domain.repository;
+
+import com.example.rework.member.domain.NonMemberEmail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+
+public interface NonMemberRepository extends JpaRepository<NonMemberEmail,Long> {
+     List<NonMemberEmail> findAllByIsAccepted(boolean isAccepted);
+}

--- a/src/main/java/com/example/rework/member/presentation/MemberController.java
+++ b/src/main/java/com/example/rework/member/presentation/MemberController.java
@@ -7,6 +7,7 @@ import com.example.rework.config.security.SecurityUtils;
 import com.example.rework.global.common.CommonResDto;
 import com.example.rework.global.error.InvalidTokenException;
 import com.example.rework.member.application.MemberService;
+import com.example.rework.member.application.dto.MemberResponseDto;
 import com.example.rework.member.application.dto.MemeberRequestDto;
 import com.example.rework.member.restapi.MemberApi;
 import jakarta.servlet.http.HttpServletRequest;
@@ -21,6 +22,8 @@ import org.springframework.security.web.authentication.logout.SecurityContextLog
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/members")
@@ -84,6 +87,23 @@ public class MemberController implements MemberApi {
         boolean result = memberService.updatePassword(updatePasswordRequestDto, securityUtils);
         return new ResponseEntity<>(
                 new CommonResDto<>(1,"패스워드변경성공",result),HttpStatus.OK
+        );
+    }
+
+    @Override
+    public ResponseEntity<CommonResDto<?>> nonMemberRegisterEmail(MemeberRequestDto.RegisterEmailRequestDto registerEmailRequestDto) {
+        boolean result = memberService.registerEmail(registerEmailRequestDto);
+
+        return new ResponseEntity<>(
+                new CommonResDto<>(1,"비회원 이메일 등록성공",result),HttpStatus.OK
+        );
+    }
+
+    @Override
+    public ResponseEntity<CommonResDto<?>> adminNonMemberEamilList(SecurityUtils securityUtils) {
+        List<MemberResponseDto  .NonMemberEmailListResponseDto> result = memberService.adminNonMemberEamilList(securityUtils);
+        return new ResponseEntity<>(
+                new CommonResDto<>(1,"승인되지 않은 이메일리스트 조회성공",result),HttpStatus.OK
         );
     }
 

--- a/src/main/java/com/example/rework/member/restapi/MemberApi.java
+++ b/src/main/java/com/example/rework/member/restapi/MemberApi.java
@@ -64,4 +64,25 @@ public interface MemberApi {
             @RequestBody MemeberRequestDto.MemberUpdatePasswordRequestDto updatePasswordRequestDto,
             SecurityUtils securityUtils
             );
+
+
+    @Operation(
+            summary = "초기 회원가입을 위한 이메일 입력하는 API입니다.",
+            description =
+                    "어떤 유저든 이메일을 등록하여 ADMIN에게 회원가입 요청을 할 수 있습니다."
+    )
+    @PostMapping("/register-email")
+    ResponseEntity<CommonResDto<?>> nonMemberRegisterEmail(
+            @RequestBody MemeberRequestDto.RegisterEmailRequestDto registerEmailRequestDto
+    );
+
+    @Operation(
+            summary = "admin이 회원가입을 승인하는 API입니다.",
+            description =
+                    "admin이 회원가입을 승인하는 API입니다."
+    )
+    @GetMapping("/admin/register-email")
+    ResponseEntity<CommonResDto<?>> adminNonMemberEamilList(
+            SecurityUtils securityUtils
+    );
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -46,6 +46,7 @@ spring:
 discord:
   webhook:
     url: ${discord_webhook_url}
+    wating-approve: ${discord.webhook.url2}
 jwt:
   secret-key: mobile_app_1234567890
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -35,6 +35,7 @@ spring:
             enable: true
 discord:
   webhook:
-    url: testDiscordWebhookUrl
+    url: testdiscordwebhook
+    wating-approve: testdiscordwebhook2
 jwt:
   secret-key: testCodeJwtToken

--- a/src/main/resources/templates/acceptEmail.html
+++ b/src/main/resources/templates/acceptEmail.html
@@ -5,76 +5,28 @@
 </head>
 <body style="background-color: #f9f9fa; margin: 0; padding: 0; -webkit-text-size-adjust: none; text-size-adjust: none;">
 
-<!-- 맨위 상단 주황색 부분 -->
-<table align="center" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="background-repeat: no-repeat; background-size: cover; background: linear-gradient(126deg, #FA00FF 4%, #0085FF 100%); border-radius: 0; color: #000000; width: 730px;" width="730">
-    <tbody>
-    <tr>
-        <td class="column column-1" style="font-weight: 200; text-align: left;vertical-align: middle; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="16.666666666666668%">
-            <table cellpadding="0" cellspacing="0" class="image_block block-2" role="presentation" width="100%">
-                <tr>
-                    <td class="pad" style="width:100%;padding-right:0px;padding-left:0px;padding-top:5px;padding-bottom:5px;">
-                        <div align="center" class="alignment" style="line-height:10px">
-                            <h1 style="display: block; height: auto; border: 0; width: 100%; color: white; padding: 15px;">Rework</h1>
-                        </div>
-                    </td>
-                </tr>
-            </table>
-        </td>
-        <td class="column column-2" style="font-weight: 200; text-align: left; padding-left: 25px; padding-right: 30px; vertical-align: middle; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="83.33333333333333%">
-            <table cellpadding="0" cellspacing="0" class="paragraph_block block-2" role="presentation" style="word-break: break-word;" width="100%">
-                <tr>
-                    <td class="pad" style="padding-top:5px;padding-bottom:5px;">
-                        <div style="color:#ffffff;direction:ltr;font-family:Inter, sans-serif;font-size:15px; font-weight:700; letter-spacing:0px; line-height:120%; text-align:right;">
-                        </div>
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-    </tbody>
-</table>
 
-<!-- 텍스트영역 -->
-<table align="center" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="background-color: #ffffff; color: #000000; width: 730px;" width="730">
-    <tbody>
-    <tr>
-        <td class="column column-1" style="font-weight: 400; text-align: left; padding-left: 25px; padding-right: 25px; vertical-align: top; padding-top: 20px; padding-bottom: 20px; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="100%">
-            <table cellpadding="0" cellspacing="0" class="heading_block block-1" role="presentation" width="100%">
-                <tr>
-                    <td class="pad" style="text-align:center;width:100%;">
-                        <h1 style="margin: 0; color: #4f5aba; direction: ltr; font-family: 'Ubuntu', Tahoma, Verdana, Segoe, sans-serif; font-size: 22px; font-weight: 700; letter-spacing: normal; line-height: 120%; text-align: left; margin-top: 0; margin-bottom: 0;">
-                        </h1>
-                    </td>
-                </tr>
-            </table>
-            <table cellpadding="0" cellspacing="0" class="paragraph_block block-3" role="presentation" style="word-break: break-word;" width="100%">
-                <tr>
-                    <td class="pad">
-                        <div style="color:#201f42;direction:ltr;font-family:Inter, sans-serif;font-size:12px;font-weight:400;letter-spacing:0px;line-height:180%;text-align:left;">
-                            <p style="margin: 0; margin-bottom: 0px;">Rework에서 랜덤비밀번호를 발급해 드립니다.</p>
-                            <p style="margin: 0; margin-bottom: 0px;"> </p>
-                            <p style="margin: 0; margin-bottom: 0px;">비밀번호 <strong th:text="${randomNumber}"></strong>입니다.</p>
-                            <p style="margin: 0; margin-bottom: 0px;">Rework에 접속하여 비밀번호를 꼭 변경해주시기리 바랍니다.</p>
-                            <p style="margin: 0; margin-bottom: 0px;">감사합니다</p>
-                        </div>
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-    </tbody>
-</table>
+<table border="0" cellpadding="0" cellspacing="0" role="module" style="table-layout:fixed;padding:0;width:100%;max-width:780px" width="100%">
+    <tbody><tr><td>
+        <div style="padding:0px;width:100%;min-width:320px;max-width:780px;font-family:Pretendard,sans-serif!important;font-size:14px;color:#393838;word-break:break-all;border-collapse:inherit;line-height:1.7"><div style="margin:0px;font-size:14px;line-height:1.7;width:100%"><p style="margin:0"><img style="max-width:100%;width:2800px;height:auto;max-width:100%" src="https://raw.githubusercontent.com/rework-kr/Asset/main/Group%2053.svg" width="2800" height="auto" class="CToWUd a6T" data-bit="iit" tabindex="0"></p><div class="a6S" dir="ltr" style="opacity: 0.01; left: 491px; top: 14px;"><span data-is-tooltip-wrapper="true" class="a5q" jsaction="JIbuQc:.CLIENT"></span></div>
 
-<!-- 맨밑의 주황색 바 -->
-<table align="center" cellpadding="0" cellspacing="0" class="row-content stack" role="presentation" style="background-size: auto; background-color: #1C1B1A; border-radius: 0; color: #000000; width: 730px;" width="730">
-    <tbody>
-    <tr>
-        <td class="column column-1" style="font-weight: 500; text-align: left; padding-left: 30px; padding-right: 10px; vertical-align: middle; border-top: 0px; border-right: 0px; border-bottom: 0px; border-left: 0px;" width="33.333333333333336%">
-            <div class="spacer_block" style="height:70px;line-height:20px;font-size:1px;"> </div>
-        </td>
-    </tr>
-    </tbody>
-</table>
+            <p>안녕하세요, 효율적인 동반 성장을 추구하는 <span style="color:rgb(34,34,34);background-color:rgb(255,255,255);text-align:start">리워</span><span style="color:rgb(34,34,34);background-color:rgb(255,255,255);text-align:start">크</span><span style="color:rgb(34,34,34);background-color:rgb(255,255,255);text-align:start">&nbsp;입니다.</span><br style="color:rgb(34,34,34);background-color:rgb(255,255,255);text-align:start"><span style="color:rgb(34,34,34);background-color:rgb(255,255,255);text-align:start"><span>리워크 서비스 이용을 위해 </span></span><span style="color:rgb(34,34,34);background-color:rgb(255,255,255);text-align:start"><strong><span style="color:rgb(23,135,238)">초대장</span></strong>을 전달드립니다 :)</span></p>
 
+            <p style="margin:0"><span style="color:rgb(34,34,34);background-color:rgb(255,255,255);text-align:start"><span style="color:rgb(34,34,34);background-color:rgb(255,255,255);text-align:start">리워크는 업무 상의 효율성을 위해 업무 리스트를 정리하던 도중 제게 필요한 서비스를 커스텀하면서, </span></span></p>
+            <p style="margin:0"><span style="color:rgb(34,34,34);background-color:rgb(255,255,255);text-align:start"><span style="color:rgb(34,34,34);background-color:rgb(255,255,255);text-align:start">조금 더 다양한 환경에서 효율적인 서비스를 이용하고자 여러분들과 공유를 시작하게 되었어요 :D</span></span></p>
+
+            <p style="margin:0">&nbsp;</p>
+            <ul style="color:rgb(34,34,34);background-color:rgb(255,255,255);text-align:start">
+                <li style="margin-left:15px">이메일 : <strong th:text="${email}"></strong></li>
+                <li style="margin-left:15px">비밀번호 : <strong th:text="${randompassword}"></strong></li><p style="color: #a8aab6;">비밀번호는 첫 로그인 시에 변경할 수 있으니 걱정하지 말아요!</p>
+            </ul>
+            <p style="margin:0">&nbsp;</p>
+            <p style="color: #222222;">항상 발전을 추구하는 리워크 동료님, 앞으로도 잘 부탁드려요<img data-emoji="🎉" class="an1" alt="🎉" aria-label="🎉" draggable="false" src="https://fonts.gstatic.com/s/e/notoemoji/15.0/1f389/72.png" loading="lazy" style="margin-left: 10px; width: 15px; height: auto;"></p>
+        </div>
+
+            <table border="0" cellpadding="0" cellspacing="0" role="module" style="table-layout:fixed;padding:0;margin-top:24px;width:100%;max-width:780px;border-top:1px solid #dddfe4" width="100%">
+            </table>
+        </div>
+    </td></tr></tbody></table>
 </body>
 </html>

--- a/src/test/java/com/example/rework/mail/application/impl/MailSenderServiceImplTest.java
+++ b/src/test/java/com/example/rework/mail/application/impl/MailSenderServiceImplTest.java
@@ -45,7 +45,7 @@ class MailSenderServiceImplTest {
         given(memberService.createMember(any())).willReturn(getMemberDto());
         given(memberRepository.findByUserId(any())).willReturn(Optional.empty());
         given(mailSenderApi.sendRandomPasswordMail(any(), any())).willReturn(true);
-        given(webhookService.sendDiscordNotification(any())).willReturn(true);
+        given(webhookService.sendDiscordNotificationForRegister(any())).willReturn(true);
         // when
         boolean result = mailSenderService.sendMail(sendMailDto);
         //then

--- a/src/test/java/com/example/rework/member/application/impl/MemberServiceImplTest.java
+++ b/src/test/java/com/example/rework/member/application/impl/MemberServiceImplTest.java
@@ -76,6 +76,8 @@ class MemberServiceImplTest {
 
         given(memberRepository.save(any(Member.class)))
                 .willReturn(getMember());
+        given(nonMemberRepository.findByEmail(any())).willReturn(getNonMember());
+
 
 
 

--- a/src/test/java/com/example/rework/member/fixture/MemberFixture.java
+++ b/src/test/java/com/example/rework/member/fixture/MemberFixture.java
@@ -20,4 +20,10 @@ public class MemberFixture {
                 .userId(mail)
                 .build();
     }
+
+    public static MemeberRequestDto.RegisterEmailRequestDto registerEmailRequestDto(String email) {
+        return MemeberRequestDto.RegisterEmailRequestDto.builder()
+                .email(email)
+                .build();
+    }
 }

--- a/src/test/java/com/example/rework/member/presentation/MemberControllerTest.java
+++ b/src/test/java/com/example/rework/member/presentation/MemberControllerTest.java
@@ -7,6 +7,8 @@ import com.example.rework.member.application.dto.MemberResponseDto;
 import com.example.rework.member.application.dto.MemeberRequestDto;
 import com.example.rework.member.application.dto.MemeberRequestDto.SignUpRequestDto;
 import com.example.rework.member.domain.Member;
+import com.example.rework.member.domain.NonMemberEmail;
+import com.example.rework.member.domain.repository.NonMemberRepository;
 import com.example.rework.member.fixture.MemberFixture;
 import com.example.rework.util.ControllerTestSupport;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -24,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -52,7 +55,8 @@ class MemberControllerTest extends ControllerTestSupport {
     EntityManager em;
 
     @Mock
-    private WebhookService webhookService;
+    private NonMemberRepository nonMemberRepository;
+
 
     private static Member initialMember;
 
@@ -61,7 +65,6 @@ class MemberControllerTest extends ControllerTestSupport {
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
         Member member = Member.builder()
                 .name("김민우1234")
                 .password(bCryptPasswordEncoder.encode(password))
@@ -69,6 +72,7 @@ class MemberControllerTest extends ControllerTestSupport {
                 .role(MemberRole.MEMBER)
                 .state(true)
                 .build();
+
         initialMember = memberRepository.saveAndFlush(member);
     }
     @AfterEach
@@ -120,14 +124,8 @@ class MemberControllerTest extends ControllerTestSupport {
     void loginMember() throws Exception {
         //given
         String url = "/api/v1/members/login";
-
-        SignUpRequestDto signUpRequestDto = MemberFixture.createMember("kbsserver3@naver.com");
-
-
-        memberService.createMember(signUpRequestDto);
-
         MemeberRequestDto.MemberLoginRequestDto memberLoginRequestDto = MemeberRequestDto.MemberLoginRequestDto.builder()
-                .userId("kbsserver3@naver.com")
+                .userId("kbsserver@naver.com")
                 .password("anstn1234@")
                 .build();
 
@@ -251,6 +249,15 @@ class MemberControllerTest extends ControllerTestSupport {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andReturn();
+    }
+
+    private NonMemberEmail getNonMember(){
+        NonMemberEmail nonMemberEmail = NonMemberEmail.builder()
+                .isAccepted(false)
+                .email("kbsserver@naver.com")
+                .build();
+        ReflectionTestUtils.setField(nonMemberEmail, "id", 1L);
+        return nonMemberEmail;
     }
 
 }


### PR DESCRIPTION
## ✨ 요약
```
Non-Member Email List - admin만 접근가능
Non-Member Email을 입력 시 discord webhook으로 admin에게 알림 전송
현우형이 제작해준 EmailTemplate으로 변경완료
Cookie값 전송을 위해 origin * -> origin 명시적으로 지정
Credential true 옵션부여
회원가입 시 nonMember 테이블 state값 변경
```

<br><br>

## 😎 해결한 이슈
- close #25 

<br><br>