### PR TITLE
Feat/27 user info

### DIFF
--- a/src/main/java/com/example/rework/member/application/MemberService.java
+++ b/src/main/java/com/example/rework/member/application/MemberService.java
@@ -2,6 +2,7 @@ package com.example.rework.member.application;
 
 import com.example.rework.config.security.SecurityUtils;
 import com.example.rework.member.application.dto.MemberResponseDto;
+import com.example.rework.member.application.dto.MemberResponseDto.MemberInfoResponseDto;
 import com.example.rework.member.application.dto.MemeberRequestDto;
 import com.example.rework.member.domain.Member;
 import org.springframework.security.core.Authentication;
@@ -20,4 +21,5 @@ public interface MemberService {
 
     List<MemberResponseDto.NonMemberEmailListResponseDto> adminNonMemberEamilList(SecurityUtils securityUtils);
 
+    MemberInfoResponseDto readMemberInfo(SecurityUtils securityUtils);
 }

--- a/src/main/java/com/example/rework/member/application/dto/MemberResponseDto.java
+++ b/src/main/java/com/example/rework/member/application/dto/MemberResponseDto.java
@@ -2,6 +2,7 @@ package com.example.rework.member.application.dto;
 
 
 
+import com.example.rework.auth.MemberRole;
 import com.example.rework.member.domain.Member;
 import com.example.rework.member.domain.NonMemberEmail;
 import jakarta.validation.constraints.NotEmpty;
@@ -18,6 +19,17 @@ public class MemberResponseDto {
 	public static class MemberLoginResponseDto {
 
 		String accessToken;
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@Builder
+	@NoArgsConstructor
+	public static class MemberInfoResponseDto {
+
+		String email;
+		boolean initialPasswordUpdateState;
+		MemberRole memberRole;
 	}
 
 	@Getter

--- a/src/main/java/com/example/rework/member/application/impl/MemberServiceImpl.java
+++ b/src/main/java/com/example/rework/member/application/impl/MemberServiceImpl.java
@@ -127,6 +127,18 @@ public class MemberServiceImpl implements MemberService {
         return result;
     }
 
+    @Override
+    public MemberResponseDto.MemberInfoResponseDto readMemberInfo(SecurityUtils securityUtils) {
+        Optional<Member> curMember = memberRepository.findByUserId(securityUtils.getCurrentUserId());
+        Member member = curMember.get();
+
+        return MemberResponseDto.MemberInfoResponseDto.builder()
+                .initialPasswordUpdateState(member.isInitialPasswordState())
+                .memberRole(member.getRole())
+                .email(member.getUserId())
+                .build();
+    }
+
 
     @Override
     public Member findMemberByUserId(String username) {

--- a/src/main/java/com/example/rework/member/domain/Member.java
+++ b/src/main/java/com/example/rework/member/domain/Member.java
@@ -32,8 +32,11 @@ public class Member extends BaseTimeEntity {
     private MemberRole role; // ADMIN 관리자 - MANAGER 운영자 - MEMBER 일반회원
     @Column(length = 30,nullable = false)
     private boolean state;
-
+    @Column(length = 30,nullable = false)
+    @Builder.Default
+    private boolean initialPasswordState=false;
     public void updatePassword(String password) {
         this.password=password;
+        this.initialPasswordState=true;
     }
 }

--- a/src/main/java/com/example/rework/member/presentation/MemberController.java
+++ b/src/main/java/com/example/rework/member/presentation/MemberController.java
@@ -8,6 +8,7 @@ import com.example.rework.global.common.CommonResDto;
 import com.example.rework.global.error.InvalidTokenException;
 import com.example.rework.member.application.MemberService;
 import com.example.rework.member.application.dto.MemberResponseDto;
+import com.example.rework.member.application.dto.MemberResponseDto.MemberInfoResponseDto;
 import com.example.rework.member.application.dto.MemeberRequestDto;
 import com.example.rework.member.restapi.MemberApi;
 import jakarta.servlet.http.HttpServletRequest;
@@ -104,6 +105,14 @@ public class MemberController implements MemberApi {
         List<MemberResponseDto  .NonMemberEmailListResponseDto> result = memberService.adminNonMemberEamilList(securityUtils);
         return new ResponseEntity<>(
                 new CommonResDto<>(1,"승인되지 않은 이메일리스트 조회성공",result),HttpStatus.OK
+        );
+    }
+
+    @Override
+    public ResponseEntity<CommonResDto<?>> readMemberInfo(SecurityUtils securityUtils) {
+        MemberInfoResponseDto memberInfoResponseDto = memberService.readMemberInfo(securityUtils);
+        return new ResponseEntity<>(
+                new CommonResDto<>(1,"유저 정보조회 성공",memberInfoResponseDto),HttpStatus.OK
         );
     }
 

--- a/src/main/java/com/example/rework/member/restapi/MemberApi.java
+++ b/src/main/java/com/example/rework/member/restapi/MemberApi.java
@@ -77,12 +77,22 @@ public interface MemberApi {
     );
 
     @Operation(
-            summary = "admin이 회원가입을 승인하는 API입니다.",
+            summary = "admin이 이메일 리스트를 확인하는 API입니다.",
             description =
-                    "admin이 회원가입을 승인하는 API입니다."
+                    "admin이 이메일 리스트를 확인하는 API입니다."
     )
     @GetMapping("/admin/register-email")
     ResponseEntity<CommonResDto<?>> adminNonMemberEamilList(
+            SecurityUtils securityUtils
+    );
+
+    @Operation(
+            summary = "유저의 정보를 조회하는 API 입니다.",
+            description =
+                    "Authorization header bearer token을 통해 유저의 정보를 조회하는 API 입니다."
+    )
+    @GetMapping("/info")
+    ResponseEntity<CommonResDto<?>> readMemberInfo(
             SecurityUtils securityUtils
     );
 }

--- a/src/test/java/com/example/rework/member/application/impl/MemberServiceImplTest.java
+++ b/src/test/java/com/example/rework/member/application/impl/MemberServiceImplTest.java
@@ -7,6 +7,7 @@ import com.example.rework.auth.repository.RefreshTokenRepository;
 import com.example.rework.discord.WebhookService;
 import com.example.rework.member.application.dto.MemberResponseDto;
 import com.example.rework.member.application.dto.MemberResponseDto.MemberCreateResponseDto;
+import com.example.rework.member.application.dto.MemberResponseDto.MemberInfoResponseDto;
 import com.example.rework.member.application.dto.MemeberRequestDto;
 import com.example.rework.member.application.dto.MemeberRequestDto.SignUpRequestDto;
 import com.example.rework.member.domain.Member;
@@ -32,6 +33,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -169,6 +172,26 @@ class MemberServiceImplTest {
 
         //then
         Assertions.assertThat(result).isEqualTo(true);
+
+    }
+
+    @DisplayName("회원의 정보를 조회할 수 있다.")
+    @Test
+    void readMemberInfoTest() throws IOException {
+        //given
+        given(memberRepository.findByUserId(any()))
+                .willReturn(Optional.ofNullable(getMember()));
+        //when
+        MemberInfoResponseDto memberInfoResponseDto = memberService.readMemberInfo(any());
+
+        //then
+        assertAll(
+                () -> assertThat(memberInfoResponseDto.getMemberRole()).isEqualTo(MemberRole.MEMBER),
+                () -> assertThat(memberInfoResponseDto.getEmail()).isEqualTo("kbsserver@naver.com"),
+                () -> assertThat(memberInfoResponseDto.isInitialPasswordUpdateState()).isEqualTo(false)
+        );
+
+
 
     }
 

--- a/src/test/java/com/example/rework/member/presentation/MemberControllerTest.java
+++ b/src/test/java/com/example/rework/member/presentation/MemberControllerTest.java
@@ -13,6 +13,7 @@ import com.example.rework.member.fixture.MemberFixture;
 import com.example.rework.util.ControllerTestSupport;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Supplier;
 import jakarta.persistence.EntityManager;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -250,6 +251,43 @@ class MemberControllerTest extends ControllerTestSupport {
                 .andExpect(status().isOk())
                 .andReturn();
     }
+    @DisplayName("유저는 자신의 정보를 확인할 수 있다.")
+    @Test
+    @WithMockUser(username = "kbsserver@naver.com",authorities = "ADMIN")
+    void test() throws Exception {
+        //given
+        String url = "/api/v1/members/info";
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(get(url)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        mvcResult.getResponse().setContentType("application/json;charset=UTF-8");
+        String result = mvcResult.getResponse().getContentAsString();
+        ObjectMapper objectMapper1 = new ObjectMapper();
+
+        JsonNode jsonNode = objectMapper1.readTree(result);
+        String email = jsonNode.get("data").get("email").asText();
+        boolean initialPasswordUpdateState = jsonNode.get("data").get("initialPasswordUpdateState").asBoolean();
+        String memberRole = jsonNode.get("data").get("memberRole").asText();
+
+
+        assertAll(
+                () -> assertThat(email).isEqualTo("kbsserver@naver.com"),
+                () -> assertThat(initialPasswordUpdateState).isEqualTo(false),
+                () -> assertThat(memberRole).isEqualTo(MemberRole.MEMBER.toString())
+        );
+
+
+    }
+
+
 
     private NonMemberEmail getNonMember(){
         NonMemberEmail nonMemberEmail = NonMemberEmail.builder()


### PR DESCRIPTION
## ✨ 요약
```
1. Member 초기에 임시비밀번호를 발급함 -> 랜덤비밀번호 사용중인 유저에게 비밀번호를 변경하라는 문구를 띄우기 위해
initinalPasswordUpdateState라는 컬럼을 추가하고 MemberInfo의 정보를 조회하기위한 API를 작성하였습니다.

```

<br><br>

## 😎 해결한 이슈
- close #27 

<br><br>